### PR TITLE
Redispatch more robustly during importdb

### DIFF
--- a/syncdb.drush.inc
+++ b/syncdb.drush.inc
@@ -133,7 +133,7 @@ function drush_syncdb($source) {
  *   List of table names within the path.
  */
 function _syncdb_parallel_import($local_dump_path) {
-  $cmd = _drush_backend_generate_command([], 'sql-query', [], drush_redispatch_get_options() + ['strict' => 0]);
+  $cmd = drush_find_drush(). ' '. _drush_backend_generate_command([], 'sql-query', [], drush_redispatch_get_options() + ['strict' => 0]);
   drush_op_system("find " . $local_dump_path . " -name '*sql' | parallel --use-cpus-instead-of-cores --jobs 200% -v $cmd --file={}");
 }
 
@@ -209,7 +209,7 @@ function drush_syncdb_importdb() {
   }
   else {
     // Manual import. Still faster than sql-sync.
-    drush_log(dt('Importing tables manually. This is still faster than sql-sync but for ludicrous speed install http://www.gnu.org/software/parallel', 'info'), 'status');
+    drush_log(dt('Importing tables manually. This is still faster than sql-sync but for ludicrous speed install http://www.gnu.org/software/parallel', 'info'));
     _syncdb_manual_import($local_dump_path, $tables);
   };
 

--- a/syncdb.drush.inc
+++ b/syncdb.drush.inc
@@ -133,8 +133,8 @@ function drush_syncdb($source) {
  *   List of table names within the path.
  */
 function _syncdb_parallel_import($local_dump_path) {
-  $db = drush_get_option('database');
-  drush_op_system("find " . $local_dump_path . " -name '*sql' | parallel --use-cpus-instead-of-cores --jobs 200% -v drush sql-query --database=$db --file={}");
+  $cmd = _drush_backend_generate_command([], 'sql-query', [], drush_redispatch_get_options() + ['strict' => FALSE]);
+  drush_op_system("find " . $local_dump_path . " -name '*sql' | parallel --use-cpus-instead-of-cores --jobs 200% -v $cmd --file={}");
 }
 
 /**
@@ -154,10 +154,9 @@ function _syncdb_manual_import($local_dump_path, $tables) {
       $invocations[] = array(
         'site' => '@self',
         'command' => 'sql-query',
-        'options' => array(
-          'file' => $local_dump_path . '/' . $table,
-          'database' => drush_get_option('database'),
-        ),
+        'options' => drush_redispatch_get_options() + ['strict' => FALSE] + array(
+            'file' => $local_dump_path . '/' . $table,
+          ),
       );
     }
     $common_options = array();

--- a/syncdb.drush.inc
+++ b/syncdb.drush.inc
@@ -133,7 +133,7 @@ function drush_syncdb($source) {
  *   List of table names within the path.
  */
 function _syncdb_parallel_import($local_dump_path) {
-  $cmd = _drush_backend_generate_command([], 'sql-query', [], drush_redispatch_get_options() + ['strict' => FALSE]);
+  $cmd = _drush_backend_generate_command([], 'sql-query', [], drush_redispatch_get_options() + ['strict' => 0]);
   drush_op_system("find " . $local_dump_path . " -name '*sql' | parallel --use-cpus-instead-of-cores --jobs 200% -v $cmd --file={}");
 }
 
@@ -154,7 +154,7 @@ function _syncdb_manual_import($local_dump_path, $tables) {
       $invocations[] = array(
         'site' => '@self',
         'command' => 'sql-query',
-        'options' => drush_redispatch_get_options() + ['strict' => FALSE] + array(
+        'options' => drush_redispatch_get_options() + ['strict' => 0] + array(
             'file' => $local_dump_path . '/' . $table,
           ),
       );


### PR DESCRIPTION
Pass along options like --root and --root to the sql-query calls in importdb. This is a robustness improvement. I tested both parallel and non-parallel code paths.

Fixes https://www.drupal.org/node/2842770