### PR TITLE
Command: dumpdb: bootsrap level: elevete.

### DIFF
--- a/syncdb.drush.inc
+++ b/syncdb.drush.inc
@@ -31,7 +31,8 @@ function syncdb_drush_command() {
   );
 
   $items['dumpdb'] = array(
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    // Database::getConnectionInfo needs higher bootstrap level
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
     'description' => 'Dumps a database into separate files into a directory.',
     'examples' => array(
       'drush dumpdb' => 'Dumps the current site\'s database into separate files.',


### PR DESCRIPTION
I have Drush version `9.0.0-beta3`.
I have Drupal version `8.3.4`.

```
$ drush dumpdb
 [error]  Exception: Unable to load Drupal settings. Check your --root, --uri, etc. in /vagrant/drupal/vendor/drush/drush/src/Sql/SqlBase.php:68
Stack trace:
#0 /vagrant/drupal/vendor/drush/drush/includes/legacy.inc(20): Drush\Sql\SqlBase::create(Array)
#1 /usr/share/drush/commands/syncdb.drush.inc(241): drush_sql_get_class()
#2 /vagrant/drupal/vendor/drush/drush/includes/command.inc(418): drush_syncdb_dumpdb()
#3 /vagrant/drupal/vendor/drush/drush/includes/command.inc(227): _drush_invoke_hooks(Array, Array)
#4 /vagrant/drupal/vendor/drush/drush/includes/command.inc(195): drush_command()
#5 /vagrant/drupal/vendor/drush/drush/src/Boot/BaseBoot.php(92): drush_dispatch(Array)
#6 /vagrant/drupal/vendor/drush/drush/includes/preflight.inc(80): Drush\Boot\BaseBoot->bootstrapAndDispatch()
#7 /vagrant/drupal/vendor/drush/drush/drush.php(10): drush_main()
#8 /vagrant/drupal/vendor/drush/drush/drush(4): require('/vagrant/drupal...')
#9 {main}
```

Apparently `dumpdb` uses `Database::getConnectionInfo()` to acquire database connection info.
In order this function to work, it needs higher bootstrap level to read in site configuration.
The fix is to set bootstrap level higher to this particular command.