### PR TITLE
Ensure trailing slash on source-dump-dir calling rsync to copy files

### DIFF
--- a/syncdb.drush.inc
+++ b/syncdb.drush.inc
@@ -103,7 +103,7 @@ function drush_syncdb($source) {
 
   // Download dump files to our local temporary directory.
   // @todo If both of these aliases are not remote, then can we avoid the rsync?
-  drush_invoke_process('@self', 'core-rsync', array($source . ':' . $source_dump_path, '@self:' . $local_dump_path), array(
+  drush_invoke_process('@self', 'core-rsync', array($source . ':' . $source_dump_path . '/', '@self:' . $local_dump_path), array(
     'yes' => TRUE,
     'compress' => TRUE,
   ));


### PR DESCRIPTION
I called `drush syncdb @live --local-dump-dir='~/drush-backups/syncdb/local' --source-dump-dir='~/drush-backups/syncdb/source'` on the test server to sync the live db. But it didn't import anything. There is no parallel on the test machine, but it should be still faster than drush sql-sync. The problem was that it didn't rsync the dump files but the complete source directory. Adding a trailing slash to the source directory fixes that, no bit deal. Adding the slash to `core-rsync` invocation won't hurt if there is already a trailing slash present but may prevent this problem.
